### PR TITLE
Adding Shift + Flip methods to TripleStore

### DIFF
--- a/src/util/DataStores/TripleStore.rs
+++ b/src/util/DataStores/TripleStore.rs
@@ -248,6 +248,27 @@ impl TripleStore {
     }
     new_store
   }
+  pub fn t_shift_me(&mut self) {
+    let mut new_store = TripleStore::new();
+    for (h, m, t) in self.iter() {
+      new_store.add((t, h, m));
+    }
+    self.0 = new_store.0;
+  }
+  pub fn h_shift_me(&mut self) {
+    let mut new_store = TripleStore::new();
+    for (h, m, t) in self.iter() {
+      new_store.add((m, t, h));
+    }
+    self.0 = new_store.0;
+  }
+  pub fn flip_me(&mut self) {
+    let mut new_store = TripleStore::new();
+    for (h, m, t) in self.iter() {
+      new_store.add((t, m, h));
+    }
+    self.0 = new_store.0;
+  }
 }
 
 /* Iterator */

--- a/src/util/DataStores/TripleStore.rs
+++ b/src/util/DataStores/TripleStore.rs
@@ -220,6 +220,35 @@ impl<'a> IntoIterator for &'a TripleStore {
     }
   }
 }
+/* Shift implementation */
+impl TripleStore {
+  /*
+    Tail Shift: (h, m, t) -> (t, h, m)
+    Head Shift: (h, m, t) -> (m, t, h)
+    Flip:       (h, m, t) -> (t, m, h)
+  */
+  pub fn t_shift(self) -> TripleStore {
+    let mut new_store = TripleStore::new();
+    for (h, m, t) in self.iter() {
+      new_store.add((t, h, m));
+    }
+    new_store
+  }
+  pub fn h_shift(self) -> TripleStore {
+    let mut new_store = TripleStore::new();
+    for (h, m, t) in self.iter() {
+      new_store.add((m, t, h));
+    }
+    new_store
+  }
+  pub fn flip(self) -> TripleStore {
+    let mut new_store = TripleStore::new();
+    for (h, m, t) in self.iter() {
+      new_store.add((t, m, h));
+    }
+    new_store
+  }
+}
 
 /* Iterator */
 pub struct TripleStoreRefIterator<'a> {


### PR DESCRIPTION
TripleStore now has 6 extra methods:
t_shift(self) -> TripleStore
h_shift(self) -> TripleStore
flip(self) -> TripleStore
t_shift_me(&mut self)
h_shift_me(&mut self)
flip_me(&mut self)

't_shift' corresponds to Tail Shift, which rearranges all data inside the TripleStore to go from (h, m, t) to (t, h, m)
'h_shift' corresponds to Head Shift, similarly rearranging from (h, m, t) to (m, t, h)
'flip' is self-explanatory, (h, m, t) to (t, m, h)

Finally, the '_me' suffix to each of the methods causes it to alter the current TripleStore rather than consuming the current on and producing a new one as the others do.